### PR TITLE
Fix whitespace between block elements

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,9 +1,9 @@
 {% capture logo_path %}{{ site.logo }}{% endcapture %}
 
 <div class="banner blm">Black Lives Matter. Support the 
-  <a href="https://www.naacpldf.org/">NAACP LDF</a>
-  <a href="https://bailproject.org/">Bail Project</a>
-  <a href="https://eji.org/">Equal Justice Initiative</a>.
+<a href="https://www.naacpldf.org/">NAACP LDF</a><!--
+--><a href="https://bailproject.org/">Bail Project</a><!--
+--><a href="https://eji.org/">Equal Justice Initiative</a>.
 </div>
 
 <script>


### PR DESCRIPTION
When you use `inline` in the CSS it leads to an extra space being added before the period. It looks weird. 
<img width="482" alt="Screen Shot 2020-06-11 at 4 13 34 PM" src="https://user-images.githubusercontent.com/32369/84448111-a8304500-abfe-11ea-8460-9294c3f32a10.png">

I read over https://css-tricks.com/fighting-the-space-between-inline-block-elements and thought the least offensive fix was to add comments. 
<img width="476" alt="Screen Shot 2020-06-11 at 4 13 16 PM" src="https://user-images.githubusercontent.com/32369/84448110-a797ae80-abfe-11ea-8bf6-00589ac9cfd9.png">

I have not tried this on mobile.